### PR TITLE
When using Harlow lib in web app, multiple requests of geojson will results in exception about simultaneous file access.

### DIFF
--- a/Harlow/Harlow/DbaseIndexer.cs
+++ b/Harlow/Harlow/DbaseIndexer.cs
@@ -38,7 +38,7 @@ namespace Harlow
             filename += ".dbf";
             _Filename = filename;
 
-            FileStream fs = new FileStream(filename, FileMode.Open);
+            FileStream fs = new FileStream(filename, FileMode.Open, FileAccess.Read);
             BinaryReader br = new BinaryReader(fs);
             byte checkByte;
             byte bbuffer;

--- a/Harlow/Harlow/ShapefileIndexer.cs
+++ b/Harlow/Harlow/ShapefileIndexer.cs
@@ -36,7 +36,7 @@ namespace Harlow
             filename = filename.Remove(filename.Length - 4, 4);
             filename += ".shx";
 
-            FileStream fs = new FileStream(filename, FileMode.Open);
+            FileStream fs = new FileStream(filename, FileMode.Open, FileAccess.Read);
             BinaryReader br = new BinaryReader(fs);
 
             int i;
@@ -79,7 +79,7 @@ namespace Harlow
             filename = filename.Remove(filename.Length - 4, 4);
             filename += ".shx";
 
-            FileStream fs = new FileStream(filename, FileMode.Open);
+            FileStream fs = new FileStream(filename, FileMode.Open, FileAccess.Read);
             BinaryReader br = new BinaryReader(fs);
             int ibuffer;
 

--- a/Harlow/Harlow/ShapefileReader.cs
+++ b/Harlow/Harlow/ShapefileReader.cs
@@ -66,7 +66,7 @@ namespace Harlow
         /// </summary>
         public void LoadFile()
         {
-            FileStream fs = new FileStream(_Filename, FileMode.Open);
+            FileStream fs = new FileStream(_Filename, FileMode.Open, FileAccess.Read);
             BinaryReader br = new BinaryReader(fs);
             //VectorFeature tempFeature;
             int[] segments;


### PR DESCRIPTION
Solution: Make sure that all statements that have 'new FileStream' also include 'FileAccess.Read' parameter to allow multi-threads to call FeaturesToJson simultaneously.
